### PR TITLE
Fix button classes on forms without webform

### DIFF
--- a/template.php
+++ b/template.php
@@ -305,11 +305,11 @@ function campaignion_foundation_block_view_alter(&$data, $block) {
     $data['content']['#attributes']['class'][] = 'no-bullet';
     if (isset($data['content']['#links'])) {
       foreach ($data['content']['#links'] as &$link) {
-        $link['attributes']['class'][] = 'large';
-        $link['attributes']['class'][] = 'share';
-        $link['attributes']['class'][] = 'button';
-        $link['attributes']['class'][] = 'expanded';
-        $link['attributes']['class'][] = $link['attributes']['data-share'] . '-icon';
+        $icon = $link['attributes']['data-share'] . '-icon';
+        $link['attributes']['class'] = array_merge(
+          $link['attributes']['class'] ?? [],
+          ['large', 'expanded', 'share', 'button', $icon]
+        );
       }
     }
   }
@@ -337,14 +337,14 @@ function campaignion_foundation_form_alter(&$form, $form_state, $form_id) {
   // Edit submit button classes.
   $classes = ['large', 'expanded', 'primary', 'button'];
   foreach (array_values(['next', 'submit']) as $type) {
-    $button_classes = &$form['actions'][$type]['#attributes']['class'];
-    // Add submit button classes.
-    foreach (array_values($classes) as $class) {
-      $button_classes[] = $class;
-    }
-    // Remove `button-primary` class added by webform. We use just `primary`.
-    if ($x = array_search('button-primary', $button_classes) !== FALSE) {
-      unset($button_classes[$x]);
+    if (isset($form['actions'][$type])) {
+      $button_classes = &$form['actions'][$type]['#attributes']['class'];
+      // Remove `button-primary` class added by webform. We use just `primary`.
+      $button_classes = array_filter($button_classes, function ($class) {
+        return $class !== 'button-primary';
+      });
+      // Add submit button classes.
+      $button_classes = array_merge($button_classes, $classes);
     }
   }
   // Don’t wrap form buttons in container.

--- a/template.php
+++ b/template.php
@@ -343,8 +343,9 @@ function campaignion_foundation_form_alter(&$form, $form_state, $form_id) {
       $button_classes[] = $class;
     }
     // Remove `button-primary` class added by webform. We use just `primary`.
-    $x = array_search('button-primary', $button_classes);
-    unset($button_classes[$x]);
+    if ($x = array_search('button-primary', $button_classes) !== FALSE) {
+      unset($button_classes[$x]);
+    }
   }
   // Don’t wrap form buttons in container.
   $form['actions']['#theme_wrappers'] = [];


### PR DESCRIPTION
`TRUE`/`FALSE` are interpreted by PHP as `1`/`0` when passed as array index → `array_search()` returns `FALSE` for forms that do not use webform and thus don’t have the webform specific class, which lead to the first existing class being removed from the array instead.