### PR TITLE
Fix submit button selector for file upload JS

### DIFF
--- a/campaignion_foundation.js
+++ b/campaignion_foundation.js
@@ -10,7 +10,7 @@ Drupal.behaviors.campaignion_foundation.attach = function (context, settings) {
   // Fix for file upload with AJAX enabled.
   // See https://www.drupal.org/project/drupal/issues/1513200
   if (Drupal.file) {
-    $('input.form-submit', context).unbind('mousedown', Drupal.file.disableFields);
+    $('[type="submit"]:not([formnovalidate])', context).unbind('mousedown', Drupal.file.disableFields);
   }
 };
 


### PR DESCRIPTION
With AJAX enabled the submit button only has the `form-submit` class on the first webform step.