### PR TITLE
Make grid in region highlighted and bottom configurable

### DIFF
--- a/campaignion_foundation.info
+++ b/campaignion_foundation.info
@@ -22,12 +22,15 @@ features[] = name
 features[] = favicon
 features[] = layout_variations
 features[] = foundation_assets
+features[] = grid_options
 
 settings[toggle_logo] = 1
 settings[toggle_name] = 1
 settings[toggle_favicon] = 1
 settings[foundation_assets_css] = 'https://assets.campaignion.org/foundist-demo/v1/main.css'
 settings[foundation_assets_js] = 'https://assets.campaignion.org/foundist-demo/v1/main.js'
+settings[grid_options_highlighted] = 'default'
+settings[grid_options_bottom] = 'default'
 
 ; Regions --------------------------------------------------------------------
 ; these content regions are available for block placement

--- a/template.php
+++ b/template.php
@@ -110,6 +110,9 @@ function campaignion_foundation_preprocess_page(&$vars) {
   }
   $vars['has_sidebar'] = $has_sidebar && !$is_single_column;
   $vars['is_narrow'] = $is_single_column || (!$has_sidebar && !$has_teasers);
+  // Layout config variables.
+  $vars['highlighted_grid'] = theme_get_setting('grid_options_highlighted') ?? 'default';
+  $vars['bottom_grid'] = theme_get_setting('grid_options_bottom') ?? 'default';
 }
 
 /**

--- a/templates/page--current-webform-embedded.tpl.php
+++ b/templates/page--current-webform-embedded.tpl.php
@@ -60,6 +60,8 @@
  * - $is_narrow: TRUE when the layout asks for a narrow grid.
  * - $reversed: TRUE when the layout supports displaying the form below the
  *   main content and it is enabled.
+ * - $highlighted_grid: "default, "narrow" or "off" to disable the grid in region highlighted.
+ * - $bottom_grid: "default, "narrow" or "off" to disable the grid in region bottom.
  *
  * Regions:
  * - $page['help']: Dynamic help text, mostly for admin pages.

--- a/templates/page--current-webform-embedded.tpl.php
+++ b/templates/page--current-webform-embedded.tpl.php
@@ -1,3 +1,86 @@
+<?php
+
+/**
+ * @file
+ * Theme implementation to display an embedded Drupal page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.tpl.php template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - $base_path: The base URL path of the Drupal installation. At the very
+ *   least, this will always default to /.
+ * - $directory: The directory the template is located in, e.g. modules/system
+ *   or themes/bartik.
+ * - $is_front: TRUE if the current page is the front page.
+ * - $logged_in: TRUE if the user is registered and signed in.
+ * - $is_admin: TRUE if the user has permission to access administration pages.
+ *
+ * Site identity:
+ * - $front_page: The URL of the front page. Use this instead of $base_path,
+ *   when linking to the front page. This includes the language domain or
+ *   prefix.
+ * - $logo: The path to the logo image, as defined in theme configuration.
+ * - $site_name: The name of the site, empty when display has been disabled
+ *   in theme settings.
+ * - $site_slogan: The slogan of the site, empty when display has been disabled
+ *   in theme settings.
+ *
+ * Navigation:
+ * - $main_menu (array): An array containing the Main menu links for the
+ *   site, if they have been configured.
+ * - $secondary_menu (array): An array containing the Secondary menu links for
+ *   the site, if they have been configured.
+ * - $breadcrumb: The breadcrumb trail for the current page.
+ *
+ * Page content (in order of occurrence in the default page.tpl.php):
+ * - $title_prefix (array): An array containing additional output populated by
+ *   modules, intended to be displayed in front of the main title tag that
+ *   appears in the template.
+ * - $title: The page title, for use in the actual HTML content.
+ * - $title_suffix (array): An array containing additional output populated by
+ *   modules, intended to be displayed after the main title tag that appears in
+ *   the template.
+ * - $messages: HTML for status and error messages. Should be displayed
+ *   prominently.
+ * - $tabs (array): Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node).
+ * - $action_links (array): Actions local to the page, such as 'Add menu' on the
+ *   menu administration interface.
+ * - $feed_icons: A string of all feed icons for the current page.
+ * - $node: The node object, if there is an automatically-loaded node
+ *   associated with the page, and the node ID is the second argument
+ *   in the page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Layout (theme specfic variables):
+ * - $has_sidebar: TRUE when there is any content in a sidebar region.
+ * - $is_narrow: TRUE when the layout asks for a narrow grid.
+ * - $reversed: TRUE when the layout supports displaying the form below the
+ *   main content and it is enabled.
+ *
+ * Regions:
+ * - $page['help']: Dynamic help text, mostly for admin pages.
+ * - $page['highlighted']: Items for the highlighted content region.
+ * - $page['top']: Top content displayed before the main content.
+ * - $page['content_top']: The top part of the main content.
+ * - $page['content']: The main content of the current page.
+ * - $page['content_bottom']: The bottom part of the main content.
+ * - $page['sidebar_first']: Items for the form region.
+ * - $page['sidebar_second']: Other items for the sidebar.
+ * - $page['bottom']: Items for the bottom content region.
+ * - $page['header']: Items for the header region.
+ * - $page['footer']: Items for the footer region.
+ * - $page['widget']: Items for the widget region.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_page()
+ * @see template_process()
+ * @see html.tpl.php
+ */
+?>
 <?php if ($page['widget']): ?>
   <div id="form-outer" class="widget">
     <?php print render($page['widget']); ?>

--- a/templates/page--embedded.tpl.php
+++ b/templates/page--embedded.tpl.php
@@ -1,3 +1,86 @@
+<?php
+
+/**
+ * @file
+ * Theme implementation to display an embedded Drupal page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.tpl.php template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - $base_path: The base URL path of the Drupal installation. At the very
+ *   least, this will always default to /.
+ * - $directory: The directory the template is located in, e.g. modules/system
+ *   or themes/bartik.
+ * - $is_front: TRUE if the current page is the front page.
+ * - $logged_in: TRUE if the user is registered and signed in.
+ * - $is_admin: TRUE if the user has permission to access administration pages.
+ *
+ * Site identity:
+ * - $front_page: The URL of the front page. Use this instead of $base_path,
+ *   when linking to the front page. This includes the language domain or
+ *   prefix.
+ * - $logo: The path to the logo image, as defined in theme configuration.
+ * - $site_name: The name of the site, empty when display has been disabled
+ *   in theme settings.
+ * - $site_slogan: The slogan of the site, empty when display has been disabled
+ *   in theme settings.
+ *
+ * Navigation:
+ * - $main_menu (array): An array containing the Main menu links for the
+ *   site, if they have been configured.
+ * - $secondary_menu (array): An array containing the Secondary menu links for
+ *   the site, if they have been configured.
+ * - $breadcrumb: The breadcrumb trail for the current page.
+ *
+ * Page content (in order of occurrence in the default page.tpl.php):
+ * - $title_prefix (array): An array containing additional output populated by
+ *   modules, intended to be displayed in front of the main title tag that
+ *   appears in the template.
+ * - $title: The page title, for use in the actual HTML content.
+ * - $title_suffix (array): An array containing additional output populated by
+ *   modules, intended to be displayed after the main title tag that appears in
+ *   the template.
+ * - $messages: HTML for status and error messages. Should be displayed
+ *   prominently.
+ * - $tabs (array): Tabs linking to any sub-pages beneath the current page
+ *   (e.g., the view and edit tabs when displaying a node).
+ * - $action_links (array): Actions local to the page, such as 'Add menu' on the
+ *   menu administration interface.
+ * - $feed_icons: A string of all feed icons for the current page.
+ * - $node: The node object, if there is an automatically-loaded node
+ *   associated with the page, and the node ID is the second argument
+ *   in the page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Layout (theme specfic variables):
+ * - $has_sidebar: TRUE when there is any content in a sidebar region.
+ * - $is_narrow: TRUE when the layout asks for a narrow grid.
+ * - $reversed: TRUE when the layout supports displaying the form below the
+ *   main content and it is enabled.
+ *
+ * Regions:
+ * - $page['help']: Dynamic help text, mostly for admin pages.
+ * - $page['highlighted']: Items for the highlighted content region.
+ * - $page['top']: Top content displayed before the main content.
+ * - $page['content_top']: The top part of the main content.
+ * - $page['content']: The main content of the current page.
+ * - $page['content_bottom']: The bottom part of the main content.
+ * - $page['sidebar_first']: Items for the form region.
+ * - $page['sidebar_second']: Other items for the sidebar.
+ * - $page['bottom']: Items for the bottom content region.
+ * - $page['header']: Items for the header region.
+ * - $page['footer']: Items for the footer region.
+ * - $page['widget']: Items for the widget region.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_page()
+ * @see template_process()
+ * @see html.tpl.php
+ */
+?>
 <?php if ($page['widget']): ?>
   <div class="widget">
     <?php print render($page['widget']); ?>

--- a/templates/page--embedded.tpl.php
+++ b/templates/page--embedded.tpl.php
@@ -60,6 +60,8 @@
  * - $is_narrow: TRUE when the layout asks for a narrow grid.
  * - $reversed: TRUE when the layout supports displaying the form below the
  *   main content and it is enabled.
+ * - $highlighted_grid: "default, "narrow" or "off" to disable the grid in region highlighted.
+ * - $bottom_grid: "default, "narrow" or "off" to disable the grid in region bottom.
  *
  * Regions:
  * - $page['help']: Dynamic help text, mostly for admin pages.

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -60,6 +60,8 @@
  * - $is_narrow: TRUE when the layout asks for a narrow grid.
  * - $reversed: TRUE when the layout supports displaying the form below the
  *   main content and it is enabled.
+ * - $highlighted_grid: "default, "narrow" or "off" to disable the grid in region highlighted.
+ * - $bottom_grid: "default, "narrow" or "off" to disable the grid in region bottom.
  *
  * Regions:
  * - $page['help']: Dynamic help text, mostly for admin pages.
@@ -103,9 +105,13 @@
 
     <?php if (!empty($page['highlighted'])): ?>
     <section id="highlighted">
-      <div class="grid-container">
+      <?php if ($highlighted_grid == 'off'): ?>
+      <?php print render($page['highlighted']); ?>
+      <?php else: ?>
+      <div class="grid-container<?php print ($highlighted_grid == 'narrow' ? ' narrow' : ''); ?>">
         <?php print render($page['highlighted']); ?>
       </div>
+      <?php endif; ?>
     </section>
     <?php endif; ?>
 
@@ -246,9 +252,13 @@
 
     <?php if (!empty($page['bottom'])): ?>
     <section id="bottom">
-      <div class="grid-container">
+      <?php if ($bottom_grid == 'off'): ?>
+      <?php print render($page['bottom']); ?>
+      <?php else: ?>
+      <div class="grid-container<?php print ($bottom_grid == 'narrow' ? ' narrow' : ''); ?>">
         <?php print render($page['bottom']); ?>
       </div>
+      <?php endif; ?>
     </section>
     <?php endif; ?>
 

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -64,11 +64,16 @@
  * Regions:
  * - $page['help']: Dynamic help text, mostly for admin pages.
  * - $page['highlighted']: Items for the highlighted content region.
+ * - $page['top']: Top content displayed before the main content.
+ * - $page['content_top']: The top part of the main content.
  * - $page['content']: The main content of the current page.
- * - $page['sidebar_first']: Items for the first sidebar.
- * - $page['sidebar_second']: Items for the second sidebar.
+ * - $page['content_bottom']: The bottom part of the main content.
+ * - $page['sidebar_first']: Items for the form region.
+ * - $page['sidebar_second']: Other items for the sidebar.
+ * - $page['bottom']: Items for the bottom content region.
  * - $page['header']: Items for the header region.
  * - $page['footer']: Items for the footer region.
+ * - $page['widget']: Items for the widget region.
  *
  * @see template_preprocess()
  * @see template_preprocess_page()

--- a/templates/webform-progressbar.tpl.php
+++ b/templates/webform-progressbar.tpl.php
@@ -4,8 +4,7 @@
  * @file
  * Display the progress bar for multipage forms.
  *
- * NB: Some variables are not used as we always want to display the page/step
- * number and page/step label. We also do not want to display percentages.
+ * NB: Some variables are not used because we do not want to display percentages.
  *
  * Available variables:
  * - $node: The webform node.

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -26,4 +26,31 @@ function campaignion_foundation_form_system_theme_settings_alter(&$form, $form_s
     '#default_value' => theme_get_setting('foundation_assets_js'),
     '#description'   => t('Link to your main JS file.'),
   ];
+  $form['grid_options'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Grid options'),
+    '#collapsible' => FALSE,
+  ];
+  $form['grid_options']['grid_options_highlighted'] = [
+    '#type'          => 'select',
+    '#title'         => t('Highlighted region'),
+    '#default_value' => theme_get_setting('grid_options_highlighted'),
+    '#description'   => t('Configure the grid width used in the highlighted region.'),
+    '#options' => [
+      'default' => t('Default grid'),
+      'narrow' => t('Narrow grid'),
+      'off' => t('No grid'),
+    ],
+  ];
+  $form['grid_options']['grid_options_bottom'] = [
+    '#type'          => 'select',
+    '#title'         => t('Bottom region'),
+    '#default_value' => theme_get_setting('grid_options_bottom'),
+    '#description'   => t('Configure the grid width used in the bottom region.'),
+    '#options' => [
+      'default' => t('Default grid'),
+      'narrow' => t('Narrow grid'),
+      'off' => t('No grid'),
+    ],
+  ];
 }


### PR DESCRIPTION
Those regions do not serve a specific purpose but instead allow the installation to add arbitrary content before or after the default page content via blocks. Depending on what they are used for, a different grid width might be desired.