### PR TITLE
Update form_element_label template for Drupal 7.92

### DIFF
--- a/includes/theme_form_element_label.inc
+++ b/includes/theme_form_element_label.inc
@@ -39,7 +39,15 @@ function campaignion_foundation_form_element_label($variables) {
   elseif ($element['#title_display'] == 'invisible') {
     $attributes['class'][] = 'element-invisible';
   }
-  if (!empty($element['#id'])) {
+
+  // Use the element's ID as the default value of the "for" attribute (to
+  // associate the label with this form element), but allow this to be
+  // overridden in order to associate the label with a different form element
+  // instead.
+  if (!empty($element['#label_for'])) {
+    $attributes['for'] = $element['#label_for'];
+  }
+  elseif (!empty($element['#id'])) {
     $attributes['for'] = $element['#id'];
   }
 


### PR DESCRIPTION
Drupal 7.92 introduced a new $element['#label_for'] property that our overridden version of the theme function must also implement.

This fixes an issue with file upload elements.