### PR TITLE
clientside validation: Register global event handlers only once

### DIFF
--- a/campaignion_foundation.info
+++ b/campaignion_foundation.info
@@ -57,3 +57,4 @@ stylesheets[screen][] = campaignion_foundation.css
 
 scripts[] = "js/jquery.webform-ajax-slide.js"
 scripts[] = campaignion_foundation.js
+scripts[] = js/clientside-validation-handlers.js

--- a/campaignion_foundation.js
+++ b/campaignion_foundation.js
@@ -44,62 +44,6 @@ Drupal.behaviors.webformAjaxSlide.attach = function (context, settings) {
   });
 }
 
-// Custom clientside validation.
-Drupal.behaviors.campaignion_foundation_clientside_validation = {};
-Drupal.behaviors.campaignion_foundation_clientside_validation.attach = function (context, settings) {
-
-  // Helper function for finding the element after which to insert the error message.
-  function findWrapper ($element) {
-    // Find the input group if there is one.
-    var $group = $element.parents('.input-group');
-    if ($group.length) {
-      return $group;
-    }
-    // Find the select2 element for selects using select2.
-    if ($element.is('select') && $element.siblings('.select2-container').length) {
-      return $element.siblings('.select2-container');
-    }
-    if (!($element.is(':radio') || $element.is(':checkbox'))) {
-      return $element;
-    }
-    // Find the top/last wrapper of radio and checkbox fields.
-    var $parents = $element.parents('.form-radios, .form-checkboxes');
-    if (!$parents.length) {
-      $parents = $element.parents('.form-type-radio, .form-type-checkbox').siblings().addBack().last();
-    }
-    if (!$parents.length) {
-      $parents = $element;
-    }
-    return $parents;
-  }
-
-  // Add classes to error message and place it after the form field.
-  $('form', context).on('clientsideValidationInitialized', function() {
-    // Register custom error function with clientside validation.
-    Drupal.myClientsideValidation['campaignion_foundation_errors'] = function (error, element) {
-      $(error).addClass('form-error is-visible').insertAfter(findWrapper($(element)));
-    }
-  });
-
-  // Add classes to form elements.
-  $('form', context).on('clientsideValidationInvalid', function (event, element) {
-    if (element) {
-      var $wrapper = findWrapper($(element));
-      $(element).addClass('is-invalid-input');
-      $wrapper.siblings('label').addClass('is-invalid-label');
-      $wrapper.siblings('.form-error[for=' + element.id + ']').addClass('is-visible');
-    }
-  });
-  $('form', context).on('clientsideValidationValid', function (event, element) {
-    if (element) {
-      var $wrapper = findWrapper($(element));
-      $(element).removeClass('is-invalid-input');
-      $wrapper.siblings('label').removeClass('is-invalid-label');
-      $wrapper.siblings('.form-error[for=' + element.id + ']').removeClass('is-visible');
-    }
-  });
-};
-
 // Payment methods sliding in/out.
 Drupal.behaviors.payment_slide = {};
 Drupal.behaviors.payment_slide.attach = function (context, settings) {

--- a/js/clientside-validation-handlers.js
+++ b/js/clientside-validation-handlers.js
@@ -1,0 +1,58 @@
+/**
+ * @file Register event handlers for clientside_validation.
+ */
+
+(function ($) {
+
+// Helper function for finding the element after which to insert the error message.
+function findWrapper ($element) {
+  // Find the input group if there is one.
+  var $group = $element.parents('.input-group');
+  if ($group.length) {
+    return $group;
+  }
+  // Find the select2 element for selects using select2.
+  if ($element.is('select') && $element.siblings('.select2-container').length) {
+    return $element.siblings('.select2-container');
+  }
+  if (!($element.is(':radio') || $element.is(':checkbox'))) {
+    return $element;
+  }
+  // Find the top/last wrapper of radio and checkbox fields.
+  var $parents = $element.parents('.form-radios, .form-checkboxes');
+  if (!$parents.length) {
+    $parents = $element.parents('.form-type-radio, .form-type-checkbox').siblings().addBack().last();
+  }
+  if (!$parents.length) {
+    $parents = $element;
+  }
+  return $parents;
+}
+
+// Add classes to error message and place it after the form field.
+$(document).on('clientsideValidationInitialized', function() {
+  // Register custom error function with clientside validation.
+  Drupal.myClientsideValidation['campaignion_foundation_errors'] = function (error, element) {
+    $(error).addClass('form-error is-visible').insertAfter(findWrapper($(element)));
+  }
+});
+
+// Add classes to form elements.
+$(document).on('clientsideValidationInvalid', function (event, element) {
+  if (element) {
+    var $wrapper = findWrapper($(element));
+    $(element).addClass('is-invalid-input');
+    $wrapper.siblings('label').addClass('is-invalid-label');
+    $wrapper.siblings('.form-error[for=' + element.id + ']').addClass('is-visible');
+  }
+});
+$(document).on('clientsideValidationValid', function (event, element) {
+  if (element) {
+    var $wrapper = findWrapper($(element));
+    $(element).removeClass('is-invalid-input');
+    $wrapper.siblings('label').removeClass('is-invalid-label');
+    $wrapper.siblings('.form-error[for=' + element.id + ']').removeClass('is-visible');
+  }
+});
+
+})(jQuery);


### PR DESCRIPTION
The code already reacts only to clientside validation specific events. There is no need to additionally wait before registering the event handlers.

The old code only accidentally worked on the initial page load because Drupal.behaviors.campaignion_foundation.attach() is executed before Drupal.behaviors.clientside_validation.attach() due to alphabetic ordering. The new code doesn’t rely on this order.