### PR TITLE
fix: Add theme JS using <script type="module">

### DIFF
--- a/template.php
+++ b/template.php
@@ -103,6 +103,8 @@ function campaignion_foundation_preprocess_html(&$vars) {
     'scope' => 'footer',
     'group' => JS_THEME,
     'every_page' => TRUE,
+    'preprocess' => FALSE,
+    'attributes' => ['type' => 'module'],
   ]);
 }
 


### PR DESCRIPTION
The theme JS we build with vite assumes that its loaded using `<script type="module">` otherwise it will pollute the global namespace. That’s also how other JS might interfere with it and cause weird errors.

Needs moreonion/drupal-theming#4 in order to work.