### PR TITLE
fix(template): remove invisible file heading

### DIFF
--- a/template.php
+++ b/template.php
@@ -268,6 +268,7 @@ function campaignion_foundation_preprocess_file_entity(&$vars) {
   }
   // Remove heading for screen readers.
   if (in_array('element-invisible', $vars['title_attributes_array']['class'] ?? [])) {
+    // Simple but hacky way to make file_entity.tpl.php not render the title.
     $vars['page'] = TRUE;
   }
 }

--- a/template.php
+++ b/template.php
@@ -266,6 +266,10 @@ function campaignion_foundation_preprocess_file_entity(&$vars) {
   if ($key = array_search('contextual-links-region', $vars['classes_array'])) {
     unset($vars['classes_array'][$key]);
   }
+  // Remove heading for screen readers.
+  if (in_array('element-invisible', $vars['title_attributes_array']['class'] ?? [])) {
+    $vars['page'] = TRUE;
+  }
 }
 
 /**


### PR DESCRIPTION
File entity renders a link to the file as heading unless the page flag is set to TRUE. This is irritating for screen reader users.